### PR TITLE
Infer Project ID from Authorizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     method_source (1.0.0)
     multi_json (1.15.0)
     os (1.1.4)
-    parallel (1.23.0)
+    parallel (1.24.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ For local development, you can generate your default credentials using the [gclo
 gcloud auth application-default login 
 ```
 
+For more details about alternative methods and different environments, check the official documentation:
+[Set up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
+
 #### Required Data
 
 After choosing an option, you should have all the necessary data and access to use Gemini.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
     file_path: 'google-credentials.json',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -39,7 +38,6 @@ client = Gemini.new(
 client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -208,13 +206,12 @@ Remember that hardcoding your API key in code is unsafe; it's preferable to use 
 }
 ```
 
-**Option 2**, for the Service Account, a `google-credentials.json` file, a `PROJECT_ID`, and a `REGION`:
+**Option 2**: For the Service Account, provide a `google-credentials.json` file and a `REGION`:
 
 ```ruby
 {
   service: 'vertex-ai-api',
   file_path: 'google-credentials.json',
-  project_id: 'PROJECT_ID',
   region: 'us-east4'
 }
 ```
@@ -224,7 +221,6 @@ Remember that hardcoding your API key in code is unsafe; it's preferable to use 
 ```ruby
 {
   service: 'vertex-ai-api',
-  project_id: 'PROJECT_ID',
   region: 'us-east4'
 }
 ```
@@ -242,6 +238,15 @@ Tokyo, Japan (asia-northeast1)
 ```
 
 You can follow here if new regions are available: [Gemini API](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini)
+
+You might want to explicitly set a Google Cloud Project ID, which you can do as follows:
+
+```ruby
+{
+  service: 'vertex-ai-api',
+  project_id: 'PROJECT_ID'
+}
+```
 
 ## Usage
 
@@ -266,7 +271,6 @@ client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
     file_path: 'google-credentials.json',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -276,7 +280,6 @@ client = Gemini.new(
 client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -18,11 +18,9 @@ module Gemini
             json_key_io: File.open(config[:credentials][:file_path]),
             scope: 'https://www.googleapis.com/auth/cloud-platform'
           )
-          @project_id = @authorizer.project_id || @authorizer.quota_project_id
         else
           @authentication = :default_credentials
           @authorizer = ::Google::Auth.get_application_default
-          @project_id = @authorizer.project_id || @authorizer.quota_project_id
         end
 
         if @authentication == :service_account || @authentication == :default_credentials

--- a/template.md
+++ b/template.md
@@ -29,7 +29,6 @@ client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
     file_path: 'google-credentials.json',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -39,7 +38,6 @@ client = Gemini.new(
 client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -185,13 +183,12 @@ Remember that hardcoding your API key in code is unsafe; it's preferable to use 
 }
 ```
 
-**Option 2**, for the Service Account, a `google-credentials.json` file, a `PROJECT_ID`, and a `REGION`:
+**Option 2**: For the Service Account, provide a `google-credentials.json` file and a `REGION`:
 
 ```ruby
 {
   service: 'vertex-ai-api',
   file_path: 'google-credentials.json',
-  project_id: 'PROJECT_ID',
   region: 'us-east4'
 }
 ```
@@ -201,7 +198,6 @@ Remember that hardcoding your API key in code is unsafe; it's preferable to use 
 ```ruby
 {
   service: 'vertex-ai-api',
-  project_id: 'PROJECT_ID',
   region: 'us-east4'
 }
 ```
@@ -219,6 +215,15 @@ Tokyo, Japan (asia-northeast1)
 ```
 
 You can follow here if new regions are available: [Gemini API](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini)
+
+You might want to explicitly set a Google Cloud Project ID, which you can do as follows:
+
+```ruby
+{
+  service: 'vertex-ai-api',
+  project_id: 'PROJECT_ID'
+}
+```
 
 ## Usage
 
@@ -243,7 +248,6 @@ client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
     file_path: 'google-credentials.json',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }
@@ -253,7 +257,6 @@ client = Gemini.new(
 client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',
-    project_id: 'PROJECT_ID',
     region: 'us-east4'
   },
   options: { model: 'gemini-pro', stream: false }

--- a/template.md
+++ b/template.md
@@ -161,6 +161,9 @@ For local development, you can generate your default credentials using the [gclo
 gcloud auth application-default login 
 ```
 
+For more details about alternative methods and different environments, check the official documentation:
+[Set up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
+
 #### Required Data
 
 After choosing an option, you should have all the necessary data and access to use Gemini.


### PR DESCRIPTION
When using `google-credentials.json` or [_Application Default Credentials_](https://cloud.google.com/docs/authentication/application-default-credentials), users don't need to explicitly set the `project_id`.