### PR TITLE
Improving Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Result:
         - [Back-and-Forth Conversations](#back-and-forth-conversations)
         - [Tools (Functions) Calling](#tools-functions-calling)
     - [New Functionalities and APIs](#new-functionalities-and-apis)
+    - [Error Handling](#error-handling)
+        - [Rescuing](#rescuing)
+        - [For Short](#for-short)
+        - [Errors](#errors)
 - [Development](#development)
     - [Purpose](#purpose)
     - [Publish to RubyGems](#publish-to-rubygems)
@@ -750,6 +754,58 @@ result = client.request(
   'streamGenerateContent',
   { contents: { role: 'user', parts: { text: 'hi!' } } }
 )
+```
+
+### Error Handling
+
+#### Rescuing
+
+```ruby
+require 'gemini-ai'
+
+begin
+  client.stream_generate_content({
+    contents: { role: 'user', parts: { text: 'hi!' } }
+  })
+rescue Gemini::Errors::GeminiError => error
+  puts error.class # Gemini::Errors::RequestError
+  puts error.message # 'the server responded with status 500'
+
+  puts error.payload
+  # { contents: [{ role: 'user', parts: { text: 'hi!' } }],
+  #   generationConfig: { candidateCount: 1 },
+  #   ...
+  # }
+
+  puts error.request
+  # #<Faraday::ServerError response={:status=>500, :headers...
+end
+```
+
+#### For Short
+
+```ruby
+require 'gemini-ai/errors'
+
+begin
+  client.stream_generate_content({
+    contents: { role: 'user', parts: { text: 'hi!' } }
+  })
+rescue GeminiError => error
+  puts error.class # Gemini::Errors::RequestError
+end
+```
+
+#### Errors
+
+```ruby
+GeminiError
+
+MissingProjectIdError
+UnsupportedServiceError
+BlockWithoutStreamError
+
+RequestError
 ```
 
 ## Development

--- a/components/errors.rb
+++ b/components/errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Gemini
+  module Errors
+    class GeminiError < StandardError
+      def initialize(message = nil)
+        super(message)
+      end
+    end
+
+    class MissingProjectIdError < GeminiError; end
+    class UnsupportedServiceError < GeminiError; end
+    class BlockWithoutStreamError < GeminiError; end
+
+    class RequestError < GeminiError
+      attr_reader :request, :payload
+
+      def initialize(message = nil, request: nil, payload: nil)
+        @request = request
+        @payload = payload
+
+        super(message)
+      end
+    end
+  end
+end

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -111,11 +111,7 @@ module Gemini
 
         results.map { |result| result[:event] }
       rescue Faraday::ServerError => e
-        raise RequestError.new(
-          e.message,
-          request: e,
-          payload:
-        )
+        raise RequestError.new(e.message, request: e, payload:)
       end
 
       def safe_parse_json(raw)

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -5,6 +5,8 @@ require 'faraday'
 require 'json'
 require 'googleauth'
 
+require_relative '../components/errors'
+
 module Gemini
   module Controllers
     class Client
@@ -30,7 +32,7 @@ module Gemini
                           config[:credentials][:project_id]
                         end
 
-          raise StandardError, 'Could not determine project_id, which is required.' if @project_id.nil?
+          raise MissingProjectIdError, 'Could not determine project_id, which is required.' if @project_id.nil?
         end
 
         @address = case config[:credentials][:service]
@@ -39,7 +41,7 @@ module Gemini
                    when 'generative-language-api'
                      "https://generativelanguage.googleapis.com/v1/models/#{config[:options][:model]}"
                    else
-                     raise StandardError, "Unsupported service: #{config[:credentials][:service]}"
+                     raise UnsupportedServiceError, "Unsupported service: #{config[:credentials][:service]}"
                    end
 
         @stream = config[:options][:stream]
@@ -60,12 +62,14 @@ module Gemini
         url += "?#{params.join('&')}" if params.size.positive?
 
         if !callback.nil? && !stream_enabled
-          raise StandardError, 'You are trying to use a block without stream enabled."'
+          raise BlockWithoutStreamError, 'You are trying to use a block without stream enabled.'
         end
 
         results = []
 
-        response = Faraday.new.post do |request|
+        response = Faraday.new do |faraday|
+          faraday.response :raise_error
+        end.post do |request|
           request.url url
           request.headers['Content-Type'] = 'application/json'
           if @authentication == :service_account || @authentication == :default_credentials
@@ -106,6 +110,12 @@ module Gemini
         return safe_parse_json(response.body) unless stream_enabled
 
         results.map { |result| result[:event] }
+      rescue Faraday::ServerError => e
+        raise RequestError.new(
+          e.message,
+          request: e,
+          payload:
+        )
       end
 
       def safe_parse_json(raw)

--- a/ports/dsl/gemini-ai/errors.rb
+++ b/ports/dsl/gemini-ai/errors.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative '../../../components/errors'
+
+include Gemini::Errors

--- a/template.md
+++ b/template.md
@@ -725,6 +725,58 @@ result = client.request(
 )
 ```
 
+### Error Handling
+
+#### Rescuing
+
+```ruby
+require 'gemini-ai'
+
+begin
+  client.stream_generate_content({
+    contents: { role: 'user', parts: { text: 'hi!' } }
+  })
+rescue Gemini::Errors::GeminiError => error
+  puts error.class # Gemini::Errors::RequestError
+  puts error.message # 'the server responded with status 500'
+
+  puts error.payload
+  # { contents: [{ role: 'user', parts: { text: 'hi!' } }],
+  #   generationConfig: { candidateCount: 1 },
+  #   ...
+  # }
+
+  puts error.request
+  # #<Faraday::ServerError response={:status=>500, :headers...
+end
+```
+
+#### For Short
+
+```ruby
+require 'gemini-ai/errors'
+
+begin
+  client.stream_generate_content({
+    contents: { role: 'user', parts: { text: 'hi!' } }
+  })
+rescue GeminiError => error
+  puts error.class # Gemini::Errors::RequestError
+end
+```
+
+#### Errors
+
+```ruby
+GeminiError
+
+MissingProjectIdError
+UnsupportedServiceError
+BlockWithoutStreamError
+
+RequestError
+```
+
 ## Development
 
 ```bash


### PR DESCRIPTION
### Error Handling

#### Rescuing

```ruby
require 'gemini-ai'

begin
  client.stream_generate_content({
    contents: { role: 'user', parts: { text: 'hi!' } }
  })
rescue Gemini::Errors::GeminiError => error
  puts error.class # Gemini::Errors::RequestError
  puts error.message # 'the server responded with status 500'

  puts error.payload
  # { contents: [{ role: 'user', parts: { text: 'hi!' } }],
  #   generationConfig: { candidateCount: 1 },
  #   ...
  # }

  puts error.request
  # #<Faraday::ServerError response={:status=>500, :headers...
end
```

#### For Short

```ruby
require 'gemini-ai/errors'

begin
  client.stream_generate_content({
    contents: { role: 'user', parts: { text: 'hi!' } }
  })
rescue GeminiError => error
  puts error.class # Gemini::Errors::RequestError
end
```

#### Errors

```ruby
GeminiError

MissingProjectIdError
UnsupportedServiceError
BlockWithoutStreamError

RequestError
```