### PR TITLE
Lower googleauth gemspec version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     gemini-ai (3.1.0)
       event_stream_parser (~> 1.0)
       faraday (~> 2.8, >= 2.8.1)
-      googleauth (~> 1.9, >= 1.9.1)
+      googleauth (~> 1.2, >= 1.9.1)
 
 GEM
   remote: https://rubygems.org/

--- a/gemini-ai.gemspec
+++ b/gemini-ai.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'event_stream_parser', '~> 1.0'
   spec.add_dependency 'faraday', '~> 2.8', '>= 2.8.1'
-  spec.add_dependency 'googleauth', '~> 1.9', '>= 1.9.1'
+  spec.add_dependency 'googleauth', '~> 1.2', '>= 1.9.1'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Lower the required version of googleauth gem.
This is because fog-google requires a lower version of the gem