### PR TITLE
Lower googleauth gem version requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     gemini-ai (3.1.0)
       event_stream_parser (~> 1.0)
       faraday (~> 2.8, >= 2.8.1)
-      googleauth (~> 1.9, >= 1.9.1)
+      googleauth (>= 1.8)
 
 GEM
   remote: https://rubygems.org/

--- a/gemini-ai.gemspec
+++ b/gemini-ai.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'event_stream_parser', '~> 1.0'
   spec.add_dependency 'faraday', '~> 2.8', '>= 2.8.1'
-  spec.add_dependency 'googleauth', '~> 1.9', '>= 1.9.1'
+  spec.add_dependency 'googleauth', '>= 1.8'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
Lowering the googleauth gem requirement makes this gem compatible with newer versions of fog-google.

The 1.8 and 1.9 API seem the same https://my.diffend.io/gems/googleauth/1.8.1/1.9.1

However, due to dependencies between various gems, we are unable to use 1.9.1 due to a dependency mismatch.
I would prefer not to fork the gem if possible, and submitting this in the hope it can be considered and may help others

Here is the issue from bundling with the current versions

````bash
Could not find compatible versions

Because every version of gemini-ai depends on googleauth >= 1.9.1, < 2.A
  and googleauth >= 1.9.1 depends on google-cloud-env ~> 2.1,
  every version of gemini-ai requires google-cloud-env ~> 2.1.
And because fog-google >= 1.11.0 depends on google-cloud-env ~> 1.2,
  every version of gemini-ai is incompatible with fog-google >= 1.11.0.
So, because Gemfile depends on fog-google ~> 1.22
  and Gemfile depends on gemini-ai >= 0,
  version solving has failed.
```
