### PR TITLE
Fixing streaming by migrating to Typhoeus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gemspec
 group :test, :development do
   gem 'dotenv', '~> 2.8', '>= 2.8.1'
   gem 'pry-byebug', '~> 3.10', '>= 3.10.1'
-  gem 'rubocop', '~> 1.58'
+  gem 'rubocop', '~> 1.60', '>= 1.60.1'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,9 @@ PATH
     gemini-ai (3.1.3)
       event_stream_parser (~> 1.0)
       faraday (~> 2.9)
+      faraday-typhoeus (~> 1.1)
       googleauth (~> 1.8)
+      typhoeus (~> 1.4, >= 1.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -15,11 +17,17 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     dotenv (2.8.1)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     event_stream_parser (1.0.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    faraday-typhoeus (1.1.0)
+      faraday (~> 2.0)
+      typhoeus (~> 1.4)
+    ffi (1.16.3)
     google-cloud-env (2.1.0)
       faraday (>= 1.0, < 3.a)
     googleauth (1.9.1)
@@ -38,7 +46,7 @@ GEM
       uri
     os (1.1.4)
     parallel (1.24.0)
-    parser (3.3.0.3)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     pry (0.14.2)
@@ -52,11 +60,11 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
-    rubocop (1.59.0)
+    rubocop (1.60.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -71,6 +79,8 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
 
@@ -81,7 +91,7 @@ DEPENDENCIES
   dotenv (~> 2.8, >= 2.8.1)
   gemini-ai!
   pry-byebug (~> 3.10, >= 3.10.1)
-  rubocop (~> 1.58)
+  rubocop (~> 1.60, >= 1.60.1)
 
 BUNDLED WITH
    2.4.22

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -20,16 +20,9 @@ module Gemini
       def initialize(config)
         @service = config[:credentials][:service]
 
-        @service_version = config.dig(:credentials, :version) || DEFAULT_SERVICE_VERSION
-
-        @address = case @service
-                   when 'vertex-ai-api'
-                     "https://#{config[:credentials][:region]}-aiplatform.googleapis.com/#{@service_version}/projects/#{@project_id}/locations/#{config[:credentials][:region]}/publishers/google/models/#{config[:options][:model]}"
-                   when 'generative-language-api'
-                     "https://generativelanguage.googleapis.com/#{@service_version}/models/#{config[:options][:model]}"
-                   else
-                     raise Errors::UnsupportedServiceError, "Unsupported service: #{@service}"
-                   end
+        unless %w[vertex-ai-api generative-language-api].include?(@service)
+          raise Errors::UnsupportedServiceError, "Unsupported service: #{@service}"
+        end
 
         if config[:credentials][:api_key]
           @authentication = :api_key
@@ -50,6 +43,15 @@ module Gemini
 
           raise Errors::MissingProjectIdError, 'Could not determine project_id, which is required.' if @project_id.nil?
         end
+
+        @service_version = config.dig(:credentials, :version) || DEFAULT_SERVICE_VERSION
+
+        @address = case @service
+                   when 'vertex-ai-api'
+                     "https://#{config[:credentials][:region]}-aiplatform.googleapis.com/#{@service_version}/projects/#{@project_id}/locations/#{config[:credentials][:region]}/publishers/google/models/#{config[:options][:model]}"
+                   when 'generative-language-api'
+                     "https://generativelanguage.googleapis.com/#{@service_version}/models/#{config[:options][:model]}"
+                   end
 
         @server_sent_events = config.dig(:options, :server_sent_events)
 

--- a/gemini-ai.gemspec
+++ b/gemini-ai.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'event_stream_parser', '~> 1.0'
   spec.add_dependency 'faraday', '~> 2.9'
+  spec.add_dependency 'faraday-typhoeus', '~> 1.1'
   spec.add_dependency 'googleauth', '~> 1.8'
+  spec.add_dependency 'typhoeus', '~> 1.4', '>= 1.4.1'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/template.md
+++ b/template.md
@@ -233,6 +233,43 @@ You might want to explicitly set a Google Cloud Project ID, which you can do as 
 }
 ```
 
+### Custom Version
+
+By default, the gem uses the `v1` version of the APIs. You may want to use a different version:
+
+```ruby
+# With an API key
+client = Gemini.new(
+  credentials: {
+    service: 'generative-language-api',
+    api_key: ENV['GOOGLE_API_KEY'],
+    version: 'v1beta'
+  },
+  options: { model: 'gemini-pro', server_sent_events: true }
+)
+
+# With a Service Account Credentials File
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    file_path: 'google-credentials.json',
+    region: 'us-east4',
+    version: 'v1beta'
+  },
+  options: { model: 'gemini-pro', server_sent_events: true }
+)
+
+# With Application Default Credentials
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    region: 'us-east4',
+    version: 'v1beta'
+  },
+  options: { model: 'gemini-pro', server_sent_events: true }
+)
+```
+
 ## Usage
 
 ### Client
@@ -838,6 +875,24 @@ result = client.request(
 ```
 
 ### Request Options
+
+#### Adapter
+
+To enable streaming, the gem uses [Faraday](https://github.com/lostisland/faraday) with the [Typhoeus](https://github.com/typhoeus/typhoeus) adapter by default.
+
+You can use a different adapter if you want:
+
+```ruby
+require 'faraday/net_http'
+
+client = Gemini.new(
+  credentials: { service: 'vertex-ai-api', region: 'us-east4' },
+  options: {
+    model: 'gemini-pro',
+    connection: { adapter: :net_http }
+  }
+)
+```
 
 #### Timeout
 


### PR DESCRIPTION
- Fixes #11
- Adds [Typhoeus](https://github.com/typhoeus/typhoeus) as the default [Faraday](https://github.com/lostisland/faraday) adapter.

New option to customize Faraday adapter:
```ruby
require 'faraday/net_http'

client = Gemini.new(
  credentials: { service: 'vertex-ai-api', region: 'us-east4' },
  options: {
    model: 'gemini-pro',
    connection: { adapter: :net_http }
  }
)
```

New option to set service version:
```ruby
client = Gemini.new(
  credentials: {
    service: 'generative-language-api',
    api_key: ENV['GOOGLE_API_KEY'],
    version: 'v1beta'
  },
  options: { model: 'gemini-pro', server_sent_events: true }
)
```

**Why is Typhoeus the default rather than being used only for streaming with server-sent events?**
I prefer using a single adapter for all use cases to ensure a consistent experience across different scenarios, e.g., to avoid having different timeout behaviors due to an unknown change of adapters under the hood. But, users can still choose another adapter if they want to.

**Why Typhoeus?**
Faraday's default adapter (Net::HTTP), specifically for the peculiar way that Google implements streaming in their APIs, is [not capable](https://stackoverflow.com/questions/35495016/stream-the-response-body-of-an-http-get-to-an-http-post-with-ruby) of actually streaming data. We need an adapter with support for [_Response Streaming + Parallel Requests_](https://github.com/lostisland/awesome-faraday/?tab=readme-ov-file#adapters), which leads to the following options:
- [Async::HTTP::Faraday](https://github.com/socketry/async-http-faraday)
- [Typhoeus](https://github.com/dleavitt/faraday-typhoeus)
- [httpx](https://gitlab.com/os85/httpx)

[async-http](https://github.com/socketry/async-http) adds [async](https://github.com/socketry/async), which feels like adding an extra layer of dependency and potential complexity (`Async do`) unnecessary to the gem.

[httpx](https://gitlab.com/os85/httpx) seems promising, but for some reason, it does not work out of the box for the purpose of understanding Google's particular way of streaming.

[Typhoeus](https://github.com/typhoeus/typhoeus) just works out of the box, backed by `libcurl` that is something widely available and supported. Both timeouts and image/video modes work as expected.