### PR TITLE
Adding new methods and models support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.gem
 .devcontainer
 .env
+*.tmp
+*.temp
+temp.rb
+tmp.rb

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -46,12 +46,19 @@ module Gemini
 
         @service_version = config.dig(:credentials, :version) || DEFAULT_SERVICE_VERSION
 
-        @address = case @service
-                   when 'vertex-ai-api'
-                     "https://#{config[:credentials][:region]}-aiplatform.googleapis.com/#{@service_version}/projects/#{@project_id}/locations/#{config[:credentials][:region]}/publishers/google/models/#{config[:options][:model]}"
-                   when 'generative-language-api'
-                     "https://generativelanguage.googleapis.com/#{@service_version}/models/#{config[:options][:model]}"
-                   end
+        @base_address = case @service
+                        when 'vertex-ai-api'
+                          "https://#{config[:credentials][:region]}-aiplatform.googleapis.com/#{@service_version}/projects/#{@project_id}/locations/#{config[:credentials][:region]}"
+                        when 'generative-language-api'
+                          "https://generativelanguage.googleapis.com/#{@service_version}"
+                        end
+
+        @model_address = case @service
+                         when 'vertex-ai-api'
+                           "publishers/google/models/#{config[:options][:model]}"
+                         when 'generative-language-api'
+                           "models/#{config[:options][:model]}"
+                         end
 
         @server_sent_events = config.dig(:options, :server_sent_events)
 
@@ -68,21 +75,59 @@ module Gemini
                            end
       end
 
-      def stream_generate_content(payload, server_sent_events: nil, &callback)
-        request('streamGenerateContent', payload, server_sent_events:, &callback)
-      end
-
-      def generate_content(payload, server_sent_events: nil, &callback)
-        result = request('generateContent', payload, server_sent_events:, &callback)
+      def predict(payload, server_sent_events: nil, &callback)
+        result = request(
+          "#{@model_address}:predict", payload,
+          server_sent_events:, &callback
+        )
 
         return result.first if result.is_a?(Array) && result.size == 1
 
         result
       end
 
-      def request(path, payload, server_sent_events: nil, &callback)
+      def embed_content(payload, server_sent_events: nil, &callback)
+        result = request(
+          "#{@model_address}:embedContent", payload,
+          server_sent_events:, &callback
+        )
+
+        return result.first if result.is_a?(Array) && result.size == 1
+
+        result
+      end
+
+      def stream_generate_content(payload, server_sent_events: nil, &callback)
+        request("#{@model_address}:streamGenerateContent", payload, server_sent_events:, &callback)
+      end
+
+      def models(_server_sent_events: nil, &callback)
+        result = request(
+          'models',
+          nil, server_sent_events: false, request_method: 'GET', &callback
+        )
+
+        return result.first if result.is_a?(Array) && result.size == 1
+
+        result
+      end
+
+      def generate_content(payload, server_sent_events: nil, &callback)
+        result = request(
+          "#{@model_address}:generateContent", payload,
+          server_sent_events:, &callback
+        )
+
+        return result.first if result.is_a?(Array) && result.size == 1
+
+        result
+      end
+
+      def request(path, payload, server_sent_events: nil, request_method: 'POST', &callback)
         server_sent_events_enabled = server_sent_events.nil? ? @server_sent_events : server_sent_events
-        url = "#{@address}:#{path}"
+
+        url = "#{@base_address}/#{path}"
+
         params = []
 
         params << 'alt=sse' if server_sent_events_enabled
@@ -97,20 +142,21 @@ module Gemini
 
         results = []
 
+        method_to_call = request_method.to_s.strip.downcase.to_sym
+
         response = Faraday.new(request: @request_options) do |faraday|
           faraday.adapter @faraday_adapter
           faraday.response :raise_error
-        end.post do |request|
+        end.send(method_to_call) do |request|
           request.url url
           request.headers['Content-Type'] = 'application/json'
           if @authentication == :service_account || @authentication == :default_credentials
             request.headers['Authorization'] = "Bearer #{@authorizer.fetch_access_token!['access_token']}"
           end
 
-          request.body = payload.to_json
+          request.body = payload.to_json unless payload.nil?
 
           if server_sent_events_enabled
-
             partial_json = ''
 
             parser = EventStreamParser::Parser.new

--- a/spec/tasks/run-available-models.rb
+++ b/spec/tasks/run-available-models.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'dotenv/load'
+
+require_relative '../../ports/dsl/gemini-ai'
+
+# # References:
+# # - https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning
+# # - https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models
+
+CACHE_FILE_PATH = 'available-models.tmp'
+
+models = [
+  'gemini-pro-vision',
+  'gemini-pro',
+  'gemini-1.5-pro-preview-0514',
+  'gemini-1.5-pro-preview-0409',
+  'gemini-1.5-pro',
+  'gemini-1.5-flash-preview-0514',
+  'gemini-1.5-flash',
+  'gemini-1.0-pro-vision-latest',
+  'gemini-1.0-pro-vision-001',
+  'gemini-1.0-pro-vision',
+  'gemini-1.0-pro-latest',
+  'gemini-1.0-pro-002',
+  'gemini-1.0-pro-001',
+  'gemini-1.0-pro',
+  'text-embedding-004',
+  'embedding-001',
+  'text-multilingual-embedding-002',
+  'textembedding-gecko-multilingual@001',
+  'textembedding-gecko-multilingual@latest',
+  'textembedding-gecko@001',
+  'textembedding-gecko@002',
+  'textembedding-gecko@003',
+  'textembedding-gecko@latest'
+]
+
+def client_for(service, model)
+  credentials = if service == 'vertex-ai-api'
+                  { service: 'vertex-ai-api', region: 'us-east4' }
+                else
+                  { service: 'generative-language-api',
+                    api_key: ENV.fetch('GOOGLE_API_KEY', nil) }
+                end
+
+  Gemini.new(credentials:, options: { model:, server_sent_events: true })
+end
+
+if File.exist?(CACHE_FILE_PATH)
+  results = Marshal.load(File.read(CACHE_FILE_PATH))
+else
+  results = {}
+
+  models.each do |model|
+    %w[vertex-ai-api generative-language-api].each do |service|
+      key = "#{service}/#{model}"
+
+      client = client_for(service, model)
+
+      output = if model =~ /embed/
+                 if service == 'vertex-ai-api'
+                   client.predict(
+                     { instances: [{ content: 'What is life?' }] }
+                   )
+                 else
+                   client.embed_content(
+                     { content: { parts: [{ text: 'What is life?' }] } }
+                   )
+                 end
+               else
+                 client.stream_generate_content(
+                   { contents: { role: 'user', parts: { text: 'hi!' } } }
+                 )
+               end
+
+      results[key] = {
+        service:, model:,
+        result: 'success', output:
+      }
+
+      print '.'
+    rescue StandardError => e
+      results[key] = {
+        service:, model:,
+        result: 'error', output: e.message
+      }
+
+      print '*'
+    end
+  end
+
+  puts ''
+
+  File.write(CACHE_FILE_PATH, Marshal.dump(results))
+end
+
+puts '| Model                                    | Vertex AI | Generative Language |'
+puts '|------------------------------------------|:---------:|:-------------------:|'
+
+table = {}
+
+results.each_value do |result|
+  table[result[:model]] = { model: result[:model] } unless table.key?(result[:model])
+  table[result[:model]][result[:service]] = result[:result] == 'success' ? '✅' : '🔒'
+end
+
+table.values.sort_by { |row| models.index(row[:model]) }.each do |row|
+  puts "| #{row[:model].ljust(40)} | #{row['vertex-ai-api'].rjust(4).ljust(8)} | #{row['generative-language-api'].rjust(10).ljust(18)} |"
+end

--- a/spec/tasks/run-embed.rb
+++ b/spec/tasks/run-embed.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'dotenv/load'
+
+require_relative '../../ports/dsl/gemini-ai'
+
+client = Gemini.new(
+  credentials: {
+    service: 'generative-language-api',
+    api_key: ENV.fetch('GOOGLE_API_KEY', nil)
+  },
+  options: { model: 'text-embedding-004', server_sent_events: true }
+)
+
+result = client.embed_content(
+  { content: { parts: [{ text: 'What is life?' }] } }
+)
+
+# File.write('temp.rb', PP.pp(result, String.new))
+
+puts result.keys
+
+puts '-' * 20
+
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    region: 'us-east4'
+  },
+  options: { model: 'text-embedding-004', server_sent_events: true }
+)
+
+result = client.predict(
+  { instances: [{ content: 'What is life?' }],
+    parameters: { autoTruncate: true } }
+)
+
+puts result.keys
+
+# File.write('temp.rb', PP.pp(result, String.new))

--- a/spec/tasks/run-generate.rb
+++ b/spec/tasks/run-generate.rb
@@ -36,3 +36,23 @@ end
 puts "\n#{'-' * 20}"
 
 puts result.map { |event| event['candidates'][0]['content']['parts'][0]['text'] }.join
+
+puts '-' * 20
+
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    region: 'us-east4'
+  },
+  options: { model: 'gemini-pro', server_sent_events: true }
+)
+
+result = client.stream_generate_content(
+  { contents: { role: 'user', parts: { text: 'hi!' } } }
+) do |event, _parsed, _raw|
+  print event['candidates'][0]['content']['parts'][0]['text']
+end
+
+puts "\n#{'-' * 20}"
+
+puts result.map { |event| event['candidates'][0]['content']['parts'][0]['text'] }.join

--- a/template.md
+++ b/template.md
@@ -270,6 +270,43 @@ client = Gemini.new(
 )
 ```
 
+## Available Models
+
+These models are accessible to the repository **author** as of May 2025 in the `us-east4` region. Access to models may vary by region, user, and account. All models here are expected to work, if you can access them. This is just a reference of what a "typical" user may expect to have access to right away:
+
+| Model                                    | Vertex AI | Generative Language |
+|------------------------------------------|:---------:|:-------------------:|
+| gemini-pro-vision                        |    ✅     |          🔒         |
+| gemini-pro                               |    ✅     |          ✅         |
+| gemini-1.5-pro-preview-0514              |    ✅     |          🔒         |
+| gemini-1.5-pro-preview-0409              |    ✅     |          🔒         |
+| gemini-1.5-pro                           |    🔒     |          🔒         |
+| gemini-1.5-flash-preview-0514            |    ✅     |          🔒         |
+| gemini-1.5-flash                         |    🔒     |          🔒         |
+| gemini-1.0-pro-vision-latest             |    🔒     |          🔒         |
+| gemini-1.0-pro-vision-001                |    ✅     |          🔒         |
+| gemini-1.0-pro-vision                    |    ✅     |          🔒         |
+| gemini-1.0-pro-latest                    |    🔒     |          ✅         |
+| gemini-1.0-pro-002                       |    ✅     |          🔒         |
+| gemini-1.0-pro-001                       |    ✅     |          ✅         |
+| gemini-1.0-pro                           |    ✅     |          ✅         |
+| text-embedding-004                       |    ✅     |          ✅         |
+| embedding-001                            |    🔒     |          ✅         |
+| text-multilingual-embedding-002          |    ✅     |          🔒         |
+| textembedding-gecko-multilingual@001     |    ✅     |          🔒         |
+| textembedding-gecko-multilingual@latest  |    ✅     |          🔒         |
+| textembedding-gecko@001                  |    ✅     |          🔒         |
+| textembedding-gecko@002                  |    ✅     |          🔒         |
+| textembedding-gecko@003                  |    ✅     |          🔒         |
+| textembedding-gecko@latest               |    ✅     |          🔒         |
+
+You can follow new models at:
+
+- [Google models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models)
+  - [Model versions and lifecycle](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning)
+
+This is [the code](https://gist.github.com/gbaptista/d7390901293bce81ee12ff4ec5fed62c) used for generating this table that you can use to explore your own access.
+
 ## Usage
 
 ### Client
@@ -310,9 +347,11 @@ client = Gemini.new(
 
 ### Methods
 
-#### stream_generate_content
+#### Chat
 
-##### Receiving Stream Events
+##### stream_generate_content
+
+###### Receiving Stream Events
 
 Ensure that you have enabled [Server-Sent Events](#streaming-vs-server-sent-events-sse) before using blocks for streaming:
 
@@ -344,7 +383,7 @@ Event:
   } }
 ```
 
-##### Without Events
+###### Without Events
 
 You can use `stream_generate_content` without events:
 
@@ -384,7 +423,7 @@ result = client.stream_generate_content(
 end
 ```
 
-#### generate_content
+##### generate_content
 
 ```ruby
 result = client.generate_content(
@@ -412,6 +451,58 @@ Result:
 ```
 
 As of the writing of this README, only the `generative-language-api` service supports the `generate_content` method; `vertex-ai-api` does not.
+
+#### Embeddings
+
+##### predict
+
+Vertex AI API generates embeddings through the `predict` method ([documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings)), and you need a client set up to use an embedding model (e.g. `text-embedding-004`):
+
+```ruby
+result = client.predict(
+  { instances: [{ content: 'What is life?' }],
+    parameters: { autoTruncate: true } }
+)
+```
+
+Result:
+```ruby
+{ 'predictions' =>
+  [{ 'embeddings' =>
+     { 'statistics' => { 'truncated' => false, 'token_count' => 4 },
+       'values' =>
+       [-0.006861076690256596,
+        0.00020840796059928834,
+        -0.028549950569868088,
+        # ...
+        0.0020092015620321035,
+        0.03279878571629524,
+        -0.014905261807143688] } }],
+  'metadata' => { 'billableCharacterCount' => 11 } }
+```
+
+##### embed_content
+
+Generative Language API generates embeddings through the `embed_content` method ([documentation](https://ai.google.dev/api/rest/v1/models/embedContent)), and you need a client set up to use an embedding model (e.g. `text-embedding-004`):
+
+```ruby
+result = client.embed_content(
+  { content: { parts: [{ text: 'What is life?' }] } }
+)
+```
+
+Result:
+```ruby
+{ 'embedding' =>
+  { 'values' =>
+    [-0.0065307906,
+     -0.0001632607,
+     -0.028370803,
+
+     0.0019950708,
+     0.032798845,
+     -0.014878989] } }
+```
 
 ### Modes
 
@@ -865,12 +956,25 @@ Which will result in:
 
 ### New Functionalities and APIs
 
-Google may launch a new endpoint that we haven't covered in the Gem yet. If that's the case, you may still be able to use it through the `request` method. For example, `stream_generate_content` is just a wrapper for `google/models/gemini-pro:streamGenerateContent`, which you can call directly like this:
+Google may launch a new endpoint that we haven't covered in the Gem yet. If that's the case, you may still be able to use it through the `request` method. For example, `stream_generate_content` is just a wrapper for `models/gemini-pro:streamGenerateContent` (Generative Language API) or `publishers/google/models/gemini-pro:streamGenerateContent` (Vertex AI API), which you can call directly like this:
 
 ```ruby
+# Generative Language API
 result = client.request(
-  'streamGenerateContent',
-  { contents: { role: 'user', parts: { text: 'hi!' } } }
+  'models/gemini-pro:streamGenerateContent',
+  { contents: { role: 'user', parts: { text: 'hi!' } } },
+  request_method: 'POST',
+  server_sent_events: true
+)
+```
+
+```ruby
+# Vertex AI API
+result = client.request(
+  'publishers/google/models/gemini-pro:streamGenerateContent',
+  { contents: { role: 'user', parts: { text: 'hi!' } } },
+  request_method: 'POST',
+  server_sent_events: true
 )
 ```
 
@@ -1044,6 +1148,9 @@ These resources and references may be useful throughout your learning process.
 - [Gemini API Documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini)
 - [Vertex AI API Documentation](https://cloud.google.com/vertex-ai/docs/reference)
   - [REST Documentation](https://cloud.google.com/vertex-ai/docs/reference/rest)
+  - [Get text embeddings](https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings)
+- [Google models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models)
+  - [Model versions and lifecycle](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versioning)
 - [Google DeepMind Gemini](https://deepmind.google/technologies/gemini/)
 - [Stream responses from Generative AI models](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/streaming)
 - [Function calling](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/function-calling)


### PR DESCRIPTION
- Detaching model from base URL;
- Adding the new `predict` and `embed_content` methods;
- Validating support for Gemini 1.5 Pro and Gemini 1.5 Flash;
- Adding documentation for Embeddings generation;

**Breaking Change:** `client.request` now requires a longer portion of the path:

Before:
```ruby
client.request(
  'streamGenerateContent',
  # ...
)
```

After:
```ruby
client.request(
  'publishers/google/models/gemini-pro:streamGenerateContent',
  # ...
)
```

This breaking change should not be impactful (we infer that most users don't use `client.request` directly) and will enable the Gem to evolve in the future to support more methods and requests that are not necessarily attached to a specific model.