### PR TITLE
Add support for storing Google Cloud key as ENV var directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ client = Gemini.new(
   options: { model: 'gemini-pro', server_sent_events: true }
 )
 
+# With a Service Account Credentials File Contents
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    file_contents: ENV['GOOGLE_CREDENTIALS_FILE_CONTENTS'],
+    region: 'us-east4'
+  },
+  options: { model: 'gemini-pro', server_sent_events: true }
+)
+
 # With Application Default Credentials
 client = Gemini.new(
   credentials: {
@@ -209,7 +219,7 @@ Similar to [Option 2](#option-2-service-account-credentials-file-vertex-ai-api),
 For local development, you can generate your default credentials using the [gcloud CLI](https://cloud.google.com/sdk/gcloud) as follows:
 
 ```sh
-gcloud auth application-default login 
+gcloud auth application-default login
 ```
 
 For more details about alternative methods and different environments, check the official documentation:

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -33,6 +33,12 @@ module Gemini
             json_key_io: File.open(config[:credentials][:file_path]),
             scope: 'https://www.googleapis.com/auth/cloud-platform'
           )
+        elsif config[:credentials][:file_contents]
+          @authentication = :service_account
+          @authorizer = ::Google::Auth::ServiceAccountCredentials.make_creds(
+            json_key_io: StringIO.new(config[:credentials][:file_contents]),
+            scope: 'https://www.googleapis.com/auth/cloud-platform'
+          )
         else
           @authentication = :default_credentials
           @authorizer = ::Google::Auth.get_application_default

--- a/template.md
+++ b/template.md
@@ -163,7 +163,7 @@ Similar to [Option 2](#option-2-service-account-credentials-file-vertex-ai-api),
 For local development, you can generate your default credentials using the [gcloud CLI](https://cloud.google.com/sdk/gcloud) as follows:
 
 ```sh
-gcloud auth application-default login 
+gcloud auth application-default login
 ```
 
 For more details about alternative methods and different environments, check the official documentation:
@@ -201,7 +201,17 @@ Remember that hardcoding your API key in code is unsafe; it's preferable to use 
 }
 ```
 
-**Option 3**: For _Application Default Credentials_, omit both the `api_key` and the `file_path`:
+**Option 3**: For the Service Account, provide the raw contents of a `google-credentials.json` file and a `REGION`:
+
+```ruby
+{
+  service: 'vertex-ai-api',
+  file_contents: ENV['GOOGLE_CREDENTIALS_FILE_CONTENTS'],
+  region: 'us-east4'
+}
+```
+
+**Option 4**: For _Application Default Credentials_, omit both the `api_key` and the `file_path`:
 
 ```ruby
 {


### PR DESCRIPTION
This is a little verbose, but was in a hurry and wanted the fewest diffs.

Being able to use the key directly is much simpler for multi env production apps so we don't have to deal with files, especially when we only use Google Cloud for Vertex.