### PR TITLE
Add synchronous batch embeddings for Generative API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Result:
     - [Embeddings](#embeddings)
       - [predict](#predict)
       - [embed_content](#embed_content)
+      - [batch_embed_content](#batch_embed_content)
   - [Modes](#modes)
     - [Text](#text)
     - [Image](#image)
@@ -622,6 +623,46 @@ Result:
      0.0019950708,
      0.032798845,
      -0.014878989] } }
+```
+
+##### batch_embed_content
+
+The Generative Language API allows you to generates embedding for multiple strings at the same time using the `batch_embed_content` method ([documentation](https://ai.google.dev/api/embeddings#method:-models.batchembedcontents)).
+
+```ruby
+result = client.batch_embed_content(
+  {
+    requests: [
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [{ text: 'What is life?' }] } },
+        output_dimensionality: 64,
+        task_type: 'CLUSTERING'
+      },
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [{ text: 'What is the meaning of life?' }] }
+      }
+    ],
+  }
+)
+```
+
+Result:
+```ruby
+{"embeddings" =>
+  [{"values" =>
+     [-0.0065307966,
+      -0.000163254,
+      -0.0283708,
+      ...
+      -0.02459646]},
+   {"values" =>
+     [-0.010632273,
+      0.019375853,
+      -0.006665491,
+      ...
+      -0.024252947]}]}
 ```
 
 ### Modes

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -133,6 +133,17 @@ module Gemini
         result
       end
 
+      def batch_embed_content(payload, server_sent_events: nil, &callback)
+        result = request(
+          "#{@model_address}:batchEmbedContents", payload,
+          server_sent_events:, &callback
+        )
+
+        return result.first if result.is_a?(Array) && result.size == 1
+
+        result
+      end
+
       def stream_generate_content(payload, server_sent_events: nil, &callback)
         request("#{@model_address}:streamGenerateContent", payload, server_sent_events:, &callback)
       end

--- a/spec/tasks/run-embed.rb
+++ b/spec/tasks/run-embed.rb
@@ -22,6 +22,29 @@ puts result.keys
 
 puts '-' * 20
 
+result = client.batch_embed_content(
+  {
+    requests: [
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [ {text: 'What is life?' } ] },
+        output_dimensionality: 64,
+        task_type: "CLUSTERING"
+      },
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [ {text: 'What is the meaning of life?' } ] },
+        output_dimensionality: 64,
+        task_type: "CLUSTERING"
+      }
+    ]
+  }
+)
+
+puts result.keys
+
+puts '-' * 20
+
 client = Gemini.new(
   credentials: {
     service: 'vertex-ai-api',

--- a/template.md
+++ b/template.md
@@ -573,6 +573,46 @@ Result:
      -0.014878989] } }
 ```
 
+##### batch_embed_content
+
+The Generative Language API allows you to generates embedding for multiple strings at the same time using the `batch_embed_content` method ([documentation](https://ai.google.dev/api/embeddings#method:-models.batchembedcontents)).
+
+```ruby
+result = client.batch_embed_content(
+  {
+    requests: [
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [{ text: 'What is life?' }] } },
+        output_dimensionality: 64,
+        task_type: 'CLUSTERING'
+      },
+      {
+        model: 'models/text-embedding-004',
+        content: { parts: [{ text: 'What is the meaning of life?' }] }
+      }
+    ],
+  }
+)
+```
+
+Result:
+```ruby
+{"embeddings" =>
+  [{"values" =>
+     [-0.0065307966,
+      -0.000163254,
+      -0.0283708,
+      ...
+      -0.02459646]},
+   {"values" =>
+     [-0.010632273,
+      0.019375853,
+      -0.006665491,
+      ...
+      -0.024252947]}]}
+```
+
 ### Modes
 
 #### Text


### PR DESCRIPTION
Allows you to get the embeddings for multiple strings in one API request from the Generative Language API.

This is not the same as async batch embeddings.