### PR TITLE
Add Provisioned Throughput Request Type Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Result:
   - [Request Options](#request-options)
     - [Adapter](#adapter)
     - [Timeout](#timeout)
+  - [Provisioned Throughput](#provisioned-throughput)
   - [Error Handling](#error-handling)
     - [Rescuing](#rescuing)
     - [For Short](#for-short)
@@ -1374,6 +1375,41 @@ client = Gemini.new(
 )
 ```
 
+### Provisioned Throughput
+
+You can configure provisioned throughput for your requests to ensure consistent performance and availability. This feature allows you to specify how your requests should be handled in terms of resource allocation.
+
+For more detailed information about Provisioned Throughput, see the [official Google Cloud documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput?hl=en).
+
+#### Configuration Options
+
+The `provisioned_throughput` option accepts one of three values:
+
+- `dedicated`: Uses dedicated resources for your requests
+- `shared`: Uses shared resources with other users
+- `spillover`: Uses spillover resources when available
+
+Invalid values will raise an `InvalidProvisionedThroughputError`.
+
+#### Example Usage
+
+```ruby
+client = Gemini.new(
+  credentials: {
+    service: 'vertex-ai-api',
+    region: 'your-provisioned-throughput-region'
+  },
+  options: {
+    model: 'your-provisioned-throughput-model',
+    provisioned_throughput: 'dedicated' # or 'shared', 'spillover'
+  }
+)
+```
+
+#### Notes
+
+- Provisioned Throughput is only available for the `vertex-ai-api` service
+- Using this configuration without purchasing and activating Provisioned Throughput may result in 429 errors
 
 ### Error Handling
 
@@ -1424,6 +1460,7 @@ MissingProjectIdError
 UnsupportedServiceError
 ConflictingCredentialsError
 BlockWithoutServerSentEventsError
+InvalidProvisionedThroughputError
 
 RequestError
 ```

--- a/components/errors.rb
+++ b/components/errors.rb
@@ -12,6 +12,7 @@ module Gemini
     class UnsupportedServiceError < GeminiError; end
     class ConflictingCredentialsError < GeminiError; end
     class BlockWithoutServerSentEventsError < GeminiError; end
+    class InvalidProvisionedThroughputError < GeminiError; end
 
     class RequestError < GeminiError
       attr_reader :request, :payload

--- a/controllers/client.rb
+++ b/controllers/client.rb
@@ -83,6 +83,13 @@ module Gemini
                            else
                              {}
                            end
+
+        @provisioned_throughput = if @service == 'vertex-ai-api'
+                                    config.dig(:options, :provisioned_throughput)
+                                  else
+                                    nil
+                                  end
+        validate_provisioned_throughput! if @provisioned_throughput
       end
 
       def avoid_conflicting_credentials!(credentials)
@@ -98,6 +105,29 @@ module Gemini
 
         raise Errors::ConflictingCredentialsError,
               "You must choose either #{message}."
+      end
+
+      def validate_provisioned_throughput!
+        return unless @provisioned_throughput
+
+        unless @provisioned_throughput.is_a?(String)
+          raise Errors::InvalidProvisionedThroughputError, 
+                'provisioned_throughput must be a string with one of: dedicated, shared, spillover'
+        end
+
+        valid_configs = %w[dedicated shared spillover]
+        unless valid_configs.include?(@provisioned_throughput)
+          raise Errors::InvalidProvisionedThroughputError,
+                "Invalid config '#{@provisioned_throughput}'. Must be one of: #{valid_configs.join(', ')}"
+        end
+      end
+
+      def build_provisioned_throughput_headers
+        return {} unless @provisioned_throughput
+
+        {
+          'X-Vertex-AI-LLM-Request-Type' => @provisioned_throughput
+        }
       end
 
       def predict(payload, server_sent_events: nil, &callback)
@@ -186,9 +216,14 @@ module Gemini
         end.send(method_to_call) do |request|
           request.url url
           request.headers['Content-Type'] = 'application/json'
+          
           if @authentication == :service_account || @authentication == :default_credentials
             request.headers['Authorization'] = "Bearer #{@authorizer.fetch_access_token!['access_token']}"
           end
+
+
+          provisioned_headers = build_provisioned_throughput_headers
+          provisioned_headers.each { |key, value| request.headers[key] = value }
 
           request.body = payload.to_json unless payload.nil?
 

--- a/spec/controllers/client_spec.rb
+++ b/spec/controllers/client_spec.rb
@@ -45,4 +45,98 @@ RSpec.describe Gemini do
       "You must choose either 'file_contents', or 'file_path'."
     )
   end
+
+  describe 'provisioned throughput configuration' do
+    let(:vertex_ai_config) do
+      {
+        credentials: {
+          service: 'vertex-ai-api',
+          project_id: 'test-project',
+          region: 'us-central1',
+          api_key: 'test-api-key'
+        },
+        options: {
+          model: 'gemini-1.5-pro'
+        }
+      }
+    end
+
+    let(:generative_language_config) do
+      {
+        credentials: {
+          service: 'generative-language-api',
+          api_key: 'test-api-key'
+        },
+        options: {
+          model: 'gemini-1.5-pro'
+        }
+      }
+    end
+
+    context 'with vertex-ai-api service' do
+      it 'accepts valid provisioned throughput configurations' do
+        %w[dedicated shared spillover].each do |config|
+          expect do
+            described_class.new(vertex_ai_config.merge(
+              options: vertex_ai_config[:options].merge(provisioned_throughput: config)
+            ))
+          end.not_to raise_error
+        end
+      end
+
+      it 'rejects invalid provisioned throughput configurations' do
+        expect do
+          described_class.new(vertex_ai_config.merge(
+            options: vertex_ai_config[:options].merge(provisioned_throughput: 'invalid')
+          ))
+        end.to raise_error(
+          Gemini::Errors::InvalidProvisionedThroughputError,
+          "Invalid config 'invalid'. Must be one of: dedicated, shared, spillover"
+        )
+      end
+
+      it 'rejects non-string provisioned throughput configurations' do
+        expect do
+          described_class.new(vertex_ai_config.merge(
+            options: vertex_ai_config[:options].merge(provisioned_throughput: { config: 'dedicated' })
+          ))
+        end.to raise_error(
+          Gemini::Errors::InvalidProvisionedThroughputError,
+          'provisioned_throughput must be a string with one of: dedicated, shared, spillover'
+        )
+      end
+
+      it 'allows nil provisioned throughput configuration' do
+        expect do
+          described_class.new(vertex_ai_config)
+        end.not_to raise_error
+      end
+    end
+
+    context 'with generative-language-api service' do
+      it 'ignores provisioned throughput configuration' do
+        expect do
+          described_class.new(generative_language_config.merge(
+            options: generative_language_config[:options].merge(provisioned_throughput: 'dedicated')
+          ))
+        end.not_to raise_error
+      end
+
+      it 'ignores invalid provisioned throughput configuration' do
+        expect do
+          described_class.new(generative_language_config.merge(
+            options: generative_language_config[:options].merge(provisioned_throughput: 'invalid')
+          ))
+        end.not_to raise_error
+      end
+
+      it 'ignores non-string provisioned throughput configuration' do
+        expect do
+          described_class.new(generative_language_config.merge(
+            options: generative_language_config[:options].merge(provisioned_throughput: { config: 'dedicated' })
+          ))
+        end.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is this?

I added this feature because **I needed to control Provisioned Throughput request types** in Google Cloud Vertex AI.

When we use Provisioned Throughput subscriptions, the default request type is `spillover`. 
In this mode, if we use more tokens than our Provisioned Throughput limit, 
**the system will automatically switch to on-demand billing**. 
This can cause unexpected costs.

With this change, we can use a request header (`X-Vertex-AI-LLM-Request-Type`) to choose the request type we want. 
This helps us control our costs better.

### Available Request Types

- **`dedicated`**: Use only Provisioned Throughput. If we go over the limit, requests are blocked (no extra cost)
- **`shared`**: Use on-demand billing
- **`spillover`**: Use Provisioned Throughput first, then switch to on-demand when we reach the limit (default)

To avoid header injection risks, I added only the Provisioned Throughput header (`X-Vertex-AI-LLM-Request-Type`) with validated values: `dedicated`, `shared`, and `spillover`.

### Main Changes

#### 1. We can now set Provisioned Throughput request type

For `vertex-ai-api` service, we can choose the request type:

```ruby
# Example: Use 'dedicated' request type to avoid unexpected on-demand costs
client = Gemini.new(
  credentials: {
    service: 'vertex-ai-api',
    region: 'us-central1'
  },
  options: {
    model: 'gemini-2.5-pro',
    provisioned_throughput: 'dedicated'
  }
)
```

#### 2. Validation

The system checks the setting when we create a client. If we use an invalid value, we will get an `InvalidProvisionedThroughputError`.

#### 3. Documentation

I added a Provisioned Throughput section to the README with usage examples and important notes.

### Use Cases

1. **For cost control**: Use `dedicated` to only use Provisioned Throughput
2. **For flexibility**: Use `spillover` (default) to switch to on-demand when we reach the rate limit
3. **For on-demand only**: Use `shared` to use on-demand billing

### Tests

- Tests for Provisioned Throughput request type setting in Vertex AI API
- Tests to check that Generative Language API ignores this setting
- Tests for bad setting values

### Reference Links

- [Provisioned Throughput Overview - Google Cloud Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/overview)
- [Use Provisioned Throughput - Google Cloud Documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/provisioned-throughput/use-provisioned-throughput)

---

Thanks for reviewing!